### PR TITLE
Use libsecret module from runtime

### DIFF
--- a/org.mume.MMapper.json
+++ b/org.mume.MMapper.json
@@ -54,28 +54,6 @@
             ]
         },
         {
-            "name": "libsecret",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Dmanpage=false",
-                "-Dvapi=false",
-                "-Dgtk_doc=false",
-                "-Dintrospection=false"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.7.tar.xz",
-                    "sha256": "6b452e4750590a2b5617adc40026f28d2f4903de15f1250e1d1c40bfd68ed55e",
-                    "x-checker-data": {
-                        "type": "gnome",
-                        "name": "libsecret",
-                        "stable-only": true
-                    }
-                }
-            ]
-        },
-        {
             "name": "qtkeychain",
             "buildsystem": "cmake-ninja",
             "sources": [


### PR DESCRIPTION
KDE runtime version 6.10 (based on the Freedesktop runtime version **25.08**) appears to provide the **libsecret** module. 

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration. 

**Related manifest file:** 

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/libsecret.bst